### PR TITLE
Set `REMOTE_ADDR` header rather then overwriting `X-FORWARDED-FOR`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Rack::CloudflareIp
 
-Overwrites the `X_FORWARDED_FOR` HTTP header with the contents of
-`CF_CONNECTING_IP` if it's present. This makes `request.remote_ip` in
-Rails return the IP of the user making the request rather than the IP of
+Overwrites the `REMOTE_ADDR` HTTP header with the contents of
+`CF_CONNECTING_IP` if it's present. This makes `request.ip` in
+Rack return the IP of the user making the request rather than the IP of
 a Cloudflare server.
 
 ## Installation

--- a/lib/rack/cloudflare_ip.rb
+++ b/lib/rack/cloudflare_ip.rb
@@ -8,8 +8,8 @@ module Rack
 
     def call(env)
       if env.has_key?("HTTP_CF_CONNECTING_IP")
-        env["HTTP_ORIGINAL_X_FORWARDED_FOR"] = env["HTTP_X_FORWARDED_FOR"]
-        env["HTTP_X_FORWARDED_FOR"] = env["HTTP_CF_CONNECTING_IP"]
+        env["ORIGINAL_REMOTE_ADDR"] = env["REMOTE_ADDR"]
+        env["REMOTE_ADDR"] = env["HTTP_CF_CONNECTING_IP"]
       end
       @app.call(env)
     end

--- a/spec/rack/cloudflare_ip_spec.rb
+++ b/spec/rack/cloudflare_ip_spec.rb
@@ -9,8 +9,7 @@ describe Rack::CloudflareIp do
 
   def base_app
     lambda { |env|
-      headers = env.select { |k, _| k =~ /^HTTP_.*/ }
-      [200, headers, []]
+      [200, env, []]
     }
   end
 
@@ -21,26 +20,27 @@ describe Rack::CloudflareIp do
   context "with HTTP_CF_CONNECTING_IP header" do
     let(:headers) { {
       "HTTP_CF_CONNECTING_IP" => "123.123.123.123",
-      "HTTP_X_FORWARDED_FOR" => "234.234.234.234"
+      "REMOTE_ADDR" => "234.234.234.234"
     } }
 
-    it "overwrites the HTTP_X_FORWARDED_FOR header" do
-      expect(last_response.headers["HTTP_X_FORWARDED_FOR"]).to eq("123.123.123.123")
+    it "overwrites sets the REMOTE_ADDR header" do
+      puts last_response.headers
+      expect(last_response.headers["REMOTE_ADDR"]).to eq("123.123.123.123")
     end
 
-    it "saves the original header in HTTP_ORIGINAL_X_FORWARDED_FOR" do
-      expect(last_response.headers["HTTP_ORIGINAL_X_FORWARDED_FOR"])
+    it "saves the original header in ORIGINAL_REMOTE_ADDR" do
+      expect(last_response.headers["ORIGINAL_REMOTE_ADDR"])
               .to eq("234.234.234.234")
     end
   end
 
   context "without HTTP_CF_CONNECTING_IP header" do
     let(:headers) { {
-      "HTTP_X_FORWARDED_FOR" => "234.234.234.234"
+      "REMOTE_ADDR" => "234.234.234.234"
     } }
 
-    it "doesn't modify the HTTP_X_FORWARDED_FOR header" do
-      expect(last_response.headers["HTTP_X_FORWARDED_FOR"]).to eq("234.234.234.234")
+    it "doesn't modify the REMOTE_ADDR header" do
+      expect(last_response.headers["REMOTE_ADDR"]).to eq("234.234.234.234")
     end
   end
 end


### PR DESCRIPTION
This allows the `REMOTE_ADDR` header to be picked up in Rack here:

https://github.com/rack/rack/blob/master/lib/rack/request.rb#L274
